### PR TITLE
Removed provides and conflict

### DIFF
--- a/pkgbuilds/stable/PKGBUILD
+++ b/pkgbuilds/stable/PKGBUILD
@@ -9,8 +9,6 @@ url="https://github.com/manolomartinez/greg"
 license=('GPL')
 depends=('python-feedparser')
 optdepends=('python3-stagger-svn: writing tags')
-provides=('greg')
-conflicts=('greg-git')
 source=("https://github.com/manolomartinez/greg/archive/${pkgver}.tar.gz")
 md5sums=('2a562128e220749d39929286a6aeffed')
 


### PR DESCRIPTION
Those aren't necessary. Especially provides. It is greg, so it's not necessary to say it is greg.
Conflict could remain, but as it is added to the git pkgbuild also not necessary. As the git version will always conflict with stable-greg
