### PR TITLE
PKGBuild Versionnumber

### DIFF
--- a/pkgbuilds/git/PKGBUILD
+++ b/pkgbuilds/git/PKGBUILD
@@ -21,7 +21,7 @@ md5sums=('SKIP')
 
 pkgver() {
   cd $_pkgname
-	git describe --always | sed -e 's|-|.|g'
+  git describe --tags --always | sed -e 's|-|.|g'
 }
 
 package() {


### PR DESCRIPTION
Hi

Not a real issue so far. But I noticed something.
git describe just shows as default the last signed tag or annotated one, but not the lightweight one.

Your latest tag ist 0.3.0
But
$ git describe --always | sed -e 's|-|.|g'
will print 0.1.0.44.ga3d5ed6 for me which is not quite right.

If the --tags option is added it will show:
$ git describe --tags --always | sed -e 's|-|.|g'
0.3.0.6.ga3d5ed6
Which is the intended version. (before the commit count and the hash for the last commit)
