### PR TITLE
Completion support and stricter argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ Save `~/.profile` and run the following command in a terminal to refresh the sys
 
 Now run `greg` and you should see the greg help text displayed in your terminal.
 
+### Completion support
+
+To enable support for command line completion in bash or zsh, install the python module [argcomplete](https://pypi.python.org/pypi/argcomplete).
+
+For bash, add the following line to `~/.bashrc`:
+
+`eval "$(register-python-argcomplete greg)"`
+
+Zsh support requires adding the following lines to `~/.zshrc`:
+
+```
+autoload -U bashcompinit && bashcompinit
+eval "$(register-python-argcomplete greg)"
+```
+
+Then load the changes by running `source ~/.bashrc` or `source ~/.zshrc`.
+
+See the [argcomplete](https://pypi.python.org/pypi/argcomplete) documentation for further details.
+
 ### Installing via homebrew python3
 
 The normal pip `install --user` is disabled for homebrew Python 3, so you cannot follow the above instructions. You have 2 options:

--- a/pkgbuilds/git/PKGBUILD
+++ b/pkgbuilds/git/PKGBUILD
@@ -12,7 +12,8 @@ depends=('python-feedparser')
 optdepends=('python3-stagger-svn: writing metadata'
   'wget: alternative downloadhandler'
 	'aria2: alternative downloadhandler'
-	'python-beautifulsoup4: convert html to text for tagging')
+	'python-beautifulsoup4: convert html to text for tagging'
+    'python-argcomplete: tab completion')
 makedepends=('git')
 provides=('greg')
 conflicts=('greg')


### PR DESCRIPTION
Adds shell completion support for arguments and feed names through
'argcomplete' (https://github.com/kislyuk/argcomplete) and lets
argparse handle more of the argument validation.

-Specified 'nargs' explicitly for the arguments that call the custom
action. For options with one argument, nargs, if unspecified, will return
a string, for options with more than one argument it will return a list.
It seems simpler just to make it always return a list. For this reason
some calls to args['names'] in greg.py were changed to args['names'][0].

-Added support for multiple arguments to the 'remove' option.

-'greg list' now sorts feeds before printing them.