### PR TITLE
Add user-agent header for downloads

### DIFF
--- a/bin/greg
+++ b/bin/greg
@@ -14,5 +14,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from greg.gregparser import main 
+from greg.parser import main 
 main()

--- a/greg/aux_functions.py
+++ b/greg/aux_functions.py
@@ -26,7 +26,7 @@ import re
 import time
 import unicodedata
 import string
-from urllib.request import urlretrieve
+import urllib
 from urllib.error import URLError
 
 from pkg_resources import resource_filename
@@ -221,7 +221,11 @@ def download_handler(feed, placeholders):
         while os.path.isfile(placeholders.fullpath):
             placeholders.fullpath = placeholders.fullpath + '_'
             placeholders.filename = placeholders.filename + '_'
-        urlretrieve(placeholders.link, placeholders.fullpath)
+        opener = urllib.request.build_opener()
+        opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+        data = opener.open(placeholders.link)
+        with open(placeholders.fullpath, 'wb+') as f:
+            f.write(data.read())
     else:
         value_list = shlex.split(value)
         instruction_list = [substitute_placeholders(part, placeholders) for


### PR DESCRIPTION
I noticed that for some podcast hosts, downloads would be refused without a valid `User-Agent` header set.

This PR adds a generic `User-Agent` header to the downloader.

I also edited the import path in `bin/greg`, as it appears that `greg.gregparser` isn't a module.