### PR TITLE
Add basic substring search for `check -f`

### DIFF
--- a/greg/commands.py
+++ b/greg/commands.py
@@ -193,11 +193,14 @@ def check(args):
         url = args["url"]
         name = "DEFAULT"
     else:
-        try:
-            url = session.feeds[args["feed"]]["url"]
-            name = args["feed"]
-        except KeyError:
-            sys.exit("You don't appear to have a feed with that name.")
+        for i in session.feeds.keys():
+            if args["feed"].lower() in i.lower():
+                match = i
+                url = session.feeds[match]["url"]
+                name = args["feed"]
+                break
+        else:
+            sys.exit("You don't appear to have a feed matching that name.")
     podcast = aux.parse_podcast(url)
     for entry in enumerate(podcast.entries):
         listentry = list(entry)


### PR DESCRIPTION
When using greg, I often want to quickly check a feed without bothering to type out its whole name. For example `greg check -f philo` should get me the closest match for the feed I want ("PhilosophyBites").

Hence, add basic substring matching on lowercased strings to make this happen. This preserves existing functionality (matching on the full name) while adding new functionality (substring search).

Tested this with the example in README, and adding new feeds matching the name. Worked as expected in most cases, with one quirk being that currently it will match on the feed chronologically first by order, rather than the best match (which would be the ideal expectation).