### PR TITLE
Allow Greg Built-In Handler to Use a Filename Template

### DIFF
--- a/greg/aux_functions.py
+++ b/greg/aux_functions.py
@@ -122,8 +122,6 @@ def check_directory(placeholders):
     feed = placeholders.feed
     args = feed.args
     placeholders.directory = "This very directory"  # wink, wink
-    placeholders.fullpath = os.path.join(
-        placeholders.directory, placeholders.filename)
     try:
         if args["downloaddirectory"]:
             ensure_dir(args["downloaddirectory"])
@@ -143,8 +141,6 @@ def check_directory(placeholders):
             subdnametemplate, placeholders)
         placeholders.directory = os.path.join(download_path, subdname)
     ensure_dir(placeholders.directory)
-    placeholders.fullpath = os.path.join(
-        placeholders.directory, placeholders.filename)
     return placeholders
 
 
@@ -233,12 +229,10 @@ def download_handler(feed, placeholders):
             if fin.getcode() != 200:
                 raise URLError
             # check if fullpath allready exists
-            while os.path.isfile(placeholders.fullpath):
+            while os.path.isfile(placeholders.get_fullpath()):
                 placeholders.filename = placeholders.filename + '_'
-                placeholders.fullpath = os.path.join(
-                    placeholders.directory, placeholders.filename)
             # write content to file
-            with open(placeholders.fullpath,'wb') as fout:
+            with open(placeholders.get_fullpath(),'wb') as fout:
                 fout.write(fin.read())
     else:
         value_list = shlex.split(value)
@@ -322,7 +316,7 @@ def substitute_placeholders(inputstring, placeholders):
     newst = inputstring.format(link=placeholders.link,
                                filename=placeholders.filename,
                                directory=placeholders.directory,
-                               fullpath=placeholders.fullpath,
+                               fullpath=placeholders.get_fullpath(),
                                title=placeholders.title,
                                filename_title=placeholders.filename_title,
                                date=placeholders.date_string(),

--- a/greg/aux_functions.py
+++ b/greg/aux_functions.py
@@ -170,7 +170,7 @@ def tag(placeholders):
     Tag the file at podpath with the information in podcast and entry
     """
     # We first recover the name of the file to be tagged...
-    template = placeholders.feed.retrieve_config("file_to_tag", "{filename}")
+    template = placeholders.feed.retrieve_config("filename_template", "{filename}")
     filename = substitute_placeholders(template, placeholders)
     podpath = os.path.join(placeholders.directory, filename)
     # ... and this is it
@@ -224,6 +224,9 @@ def download_handler(feed, placeholders):
     """
     value = feed.retrieve_config('downloadhandler', 'greg')
     if value == 'greg':
+        # Get the name of the output file and set in placeholders
+        template = placeholders.feed.retrieve_config("filename_template", "{filename}")
+        placeholders.filename = substitute_placeholders(template, placeholders)
         with urlopen(placeholders.link) as fin:
             # check if request went ok
             if fin.getcode() != 200:
@@ -325,5 +328,6 @@ def substitute_placeholders(inputstring, placeholders):
                                placeholders.filename_podcasttitle,
                                name=placeholders.name,
                                subtitle=placeholders.sanitizedsubtitle,
-                               entrysummary=placeholders.entrysummary)
+                               entrysummary=placeholders.entrysummary,
+                               extension=placeholders.extension)
     return newst

--- a/greg/aux_functions.py
+++ b/greg/aux_functions.py
@@ -233,7 +233,7 @@ def download_handler(feed, placeholders):
                 raise URLError
             # check if fullpath allready exists
             while os.path.isfile(placeholders.get_fullpath()):
-                placeholders.filename = placeholders.filename + '_'
+                placeholders.filename = placeholders.get_file_basename() + '_.' + placeholders.get_extension()
             # write content to file
             with open(placeholders.get_fullpath(),'wb') as fout:
                 fout.write(fin.read())
@@ -329,5 +329,6 @@ def substitute_placeholders(inputstring, placeholders):
                                name=placeholders.name,
                                subtitle=placeholders.sanitizedsubtitle,
                                entrysummary=placeholders.entrysummary,
-                               extension=placeholders.extension)
+                               extension=placeholders.get_extension(),
+                               file_basename=placeholders.get_file_basename())
     return newst

--- a/greg/classes.py
+++ b/greg/classes.py
@@ -368,10 +368,15 @@ class Placeholders:
         self.filename_podcasttitle = aux.sanitize(self.podcasttitle)
         self.name = feed.name
         self.date = tuple(entry.linkdate)
-        self.extension = filename.split(".")[-1]
     
     def get_fullpath(self):
         return os.path.join(self.directory, self.filename)
+
+    def get_extension(self):
+        return self.filename.split(".")[-1]
+
+    def get_file_basename(self):
+        return ".".join(self.filename.split(".")[0:-1])
 
     def date_string(self):
         date_format = self.feed.retrieve_config("date_format", "%Y-%m-%d")

--- a/greg/classes.py
+++ b/greg/classes.py
@@ -351,7 +351,6 @@ class Placeholders:
         self.feed = feed
         self.link = link
         self.filename = filename
-        # self.fullpath = os.path.join(self.directory, self.filename)
         self.title = title.replace("\"", "'")
         self.filename_title = aux.sanitize(title)
         try:
@@ -369,6 +368,9 @@ class Placeholders:
         self.filename_podcasttitle = aux.sanitize(self.podcasttitle)
         self.name = feed.name
         self.date = tuple(entry.linkdate)
+    
+    def get_fullpath(self):
+        return os.path.join(self.directory, self.filename)
 
     def date_string(self):
         date_format = self.feed.retrieve_config("date_format", "%Y-%m-%d")

--- a/greg/classes.py
+++ b/greg/classes.py
@@ -368,6 +368,7 @@ class Placeholders:
         self.filename_podcasttitle = aux.sanitize(self.podcasttitle)
         self.name = feed.name
         self.date = tuple(entry.linkdate)
+        self.extension = filename.split(".")[-1]
     
     def get_fullpath(self):
         return os.path.join(self.directory, self.filename)

--- a/greg/data/greg.conf
+++ b/greg/data/greg.conf
@@ -36,6 +36,7 @@
 # {name} the name you use to refer to the podcast in greg
 # {subtitle} a description of the feed
 # {entrysummary} a summary of the podcast entry
+# {extension} best effort guess of the extension by taking the suffix (after the dot)
 #
 # If you have chosen to install BeautifulSoup, which is an optional dependency,
 # {subtitle} and {summary} will be converted from html to text. Otherwise, they
@@ -142,14 +143,6 @@ tag_genre = Podcast
 # leave it blank, like so:
 #
 # tag_comment =
-
-# Finally, if you are using a custom download handler (see below), you need to tell
-# greg how to figure out the name of the podcast files, using the file_to_tag
-# option. For example if your
-# download handler saves podcasts under a name such as "entry title.ogg", you
-# will need to add the following to the podcast's config section:
-#
-# file_to_tag = {entry}.ogg
 #
 ###############################################################################
 #
@@ -196,8 +189,19 @@ mime = audio
 # The following special case simply instructs greg to download the podcast 
 # itself.
 #
+# If you are using an external hander and wish to use tagging you must set
+# the filename_template option (see below).
+#
 downloadhandler = greg
 #
+###############################################################################
+#
+# The filename_template option pairs with the downloadhandler in two ways:
+# 1. If using greg to download, use this option to set custom names.
+# 2. If using an external handler to download, set this to match the  output
+#    filenames  if using tagging.
+#
+# filename_template = {entry}.{extension}
 ###############################################################################
 #
 # Some feeds are abnormal in that they don't use enclosures. The following

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ setup(
     name='Greg',
     version='0.4.7',
     install_requires=['feedparser'],
+    extras_require={
+        'tagging': ['beautifulsoup4', 'stagger', 'lxml'],
+    },
     description='A command-line podcast aggregator',
     author='Manolo Martínez',
     author_email='manolo@austrohungaro.com',


### PR DESCRIPTION
This PR partially address #83 (it does not attempt to add a template option for the entry ID) by converting the `file_to_tag`  option to `filename_template` and using it in `download_handler` to set the placeholders.filename.

Also it adds the following minor things:

1. `get_fullpath`  to create the full path, preventing the need to call `os.join` whenever a fullpath is needed.
2. `get_extension` to get the extension of the filename.
3. `get_file_basename` to get the filename without the extension.
4. Add extras_requires section for optional dependencies