### PR TITLE
Init tag structure if not exists

### DIFF
--- a/greg/aux_functions.py
+++ b/greg/aux_functions.py
@@ -194,6 +194,8 @@ def tag(placeholders):
         metadata = substitute_placeholders(tagdict[tag], placeholders)
         tagdict[tag] = metadata
     file_to_tag = eyed3.load(podpath)
+    if file_to_tag.tag == None:
+        file_to_tag.initTag()
     for mytag in tagdict:
         setattr(file_to_tag.tag, mytag, tagdict[mytag])
     file_to_tag.tag.save()


### PR DESCRIPTION
I had some Podcasts that would print

```
Traceback (most recent call last):
  File "bin/greg", line 33, in <module>
    sys.exit(load_entry_point('Greg', 'console_scripts', 'greg')())
  File "src/greg/greg/parser.py", line 138, in main
    function(vars(args))
  File "src/greg/greg/commands.py", line 252, in download
    feed.download_entry(entry)
  File "src/greg/greg/classes.py", line 336, in download_entry
    aux.tag(placeholders)
  File "src/greg/greg/aux_functions.py", line 212, in tag
    setattr(file_to_tag.tag, mytag, tagdict[mytag])
AttributeError: 'NoneType' object has no attribute 'artist'
```

when trying to tag them. It’s because they didn’t have any ID3 tags to begin with.