### PR TITLE
Added example for naming files in chronological order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ just stream it, like this:
 
     greg download 0 --downloadhandler "mplayer {link}"
 
+If you want to ensure that the downloaded files are in chronological order, you
+can use placeholders to add the date at the beginning, like this:
+
+    downloadhandler = wget {link} -O {directory}/{date}_{filename}
+
 One last thing: if you subscribe to a very active feed, and you are only
 interested in some of the entries, you can filter the feed. For example, if you
 only want to watch TED talks about Google, say, you can add the following line


### PR DESCRIPTION
After manually renaming about 50 files to get them in the right order, I finally figured out this solution. I think other users would benefit from it being documented. I think there’s even an argument that it should be the default, but that’s not my choice to make.