### PR TITLE
adding a placeholder for the episode/podcast description

### DIFF
--- a/greg/classes.py
+++ b/greg/classes.py
@@ -371,6 +371,7 @@ class Placeholders:
         self.name = feed.name
         self.date = tuple(entry.linkdate)
         self.itunes_episode = entry.get('itunes_episode')
+        self.item_description = entry.get('description')
 
     def date_string(self):
         date_format = self.feed.retrieve_config("date_format", "%Y-%m-%d")
@@ -393,5 +394,6 @@ class Placeholders:
                                    name=self.name,
                                    subtitle=self.sanitizedsubtitle,
                                    entrysummary=self.entrysummary,
-                                   itunes_episode = self.itunes_episode)
+                                   itunes_episode = self.itunes_episode,
+                                   item_description = self.item_description)
         return newst

--- a/greg/data/greg.conf
+++ b/greg/data/greg.conf
@@ -37,6 +37,7 @@
 # {subtitle} a description of the feed
 # {entrysummary} a summary of the podcast entry
 # {itunes_episode} podcast entry episode number from <itunes:episode>
+# {item_description} podcast episode description from <description>
 #
 # If you have chosen to install BeautifulSoup, which is an optional dependency,
 # {subtitle} and {summary} will be converted from html to text. Otherwise, they


### PR DESCRIPTION
For context, the Skeptics Guide to the Universe podcast includes the conversation topics in the description tag:

```
<item>
<title>The Skeptics Guide #880 - May 21 2022</title>
<description>
News Items: Health Benefits of Clean Energy, SIDS, Growing Plants in Lunar Soil, Milky Way Black Hole, Gullible Acupuncture Article; Who's That Noisy; Your Questions and E-mails: Language and AI, Raw Food Diet; Science or Fiction
</description>
<enclosure url="https://media.libsyn.com/media/skepticsguide/skepticast2022-05-21.mp3" length="41064304" type="audio/mpeg"/>
<pubDate>Sat, 21 May 2022 12:00:00 -0400</pubDate>
<guid>https://www.theskepticsguide.org/podcast/sgu/880</guid>
</item>
```

This PR allows us to use that description for eyeD3 tagging -- I put mine in the Comments tag of the MP3.